### PR TITLE
Implement anonymous sharing for the web client

### DIFF
--- a/src/components/FileReceive.tsx
+++ b/src/components/FileReceive.tsx
@@ -1,17 +1,32 @@
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { decryptFileWithSessionKey, importKey, RSA_ALGORITHM, unwrapSessionKey } from '@/crypto';
-import { formatFileSize } from '@/lib/utils';
+import { useAuth } from '@/context/AuthContext';
+import {
+	base64ToArrayBuffer,
+	decryptFileWithSessionKey,
+	importKey,
+	RSA_ALGORITHM,
+	unwrapSessionKey,
+} from '@/crypto';
+import { formatFileSize, fromUrlSafeBase64 } from '@/lib/utils';
 import { receiveSchema } from '@/schema/file';
 import { type File, type ReceiveInput } from '@/types/file';
 import { zodResolver } from '@hookform/resolvers/zod';
 import axios from 'axios';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Download, File as FileIcon, Loader2, Inbox, CheckCircle2, Package, ChevronLeft } from 'lucide-react';
+import {
+	Download,
+	File as FileIcon,
+	Loader2,
+	Inbox,
+	CheckCircle2,
+	Package,
+	ChevronLeft,
+} from 'lucide-react';
 import React from 'react';
 import { useState, useRef, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { useNavigate, Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { toast } from 'sonner';
 
 const FileReceive: React.FC = () => {
@@ -19,17 +34,18 @@ const FileReceive: React.FC = () => {
 	const [downloadingIndex, setDownloadingIndex] = useState<number | null>(null);
 	const [decryptionKey, setDecryptionKey] = useState<CryptoKey | null>(null);
 	const shareCode = useRef<string>('');
-	const navigate = useNavigate();
 	const {
 		register,
 		handleSubmit,
-		reset,
 		setValue,
 		formState: { errors, isSubmitting },
 	} = useForm<ReceiveInput>({
 		resolver: zodResolver(receiveSchema),
 		defaultValues: { sharingCode: '' },
 	});
+	const { user } = useAuth();
+	const location = useLocation();
+	const isAnonymousShare = useRef(false);
 
 	// Extract sharing code from URL and auto-fill input (without auto-submitting)
 	useEffect(() => {
@@ -42,59 +58,97 @@ const FileReceive: React.FC = () => {
 		}
 	}, [setValue]);
 
-	const fetchFiles = async (sharingCode: string) => {
+	useEffect(() => {
+		console.log('Location Hash:', location.hash);
+		isAnonymousShare.current = location.hash.slice(1).length > 0;
+	}, [location.hash]);
+
+	const fetchFiles = async (sharingCode: string, sharingMode: string) => {
 		try {
 			shareCode.current = sharingCode;
-			const response = await axios.get(
-				`${import.meta.env.VITE_API_BASE_URL}/api/v1/share/${sharingCode}`,
-				{ withCredentials: true }
-			);
-			const { files, encrypted_key } = response?.data?.data || {};
+			if (sharingMode === 'verified') {
+				const response = await axios.get(
+					`${import.meta.env.VITE_API_BASE_URL}/api/v1/share/${sharingCode}`,
+					{ withCredentials: true }
+				);
+				const { files, encrypted_key } = response?.data?.data || {};
 
-			if (!encrypted_key) {
-				// If no key, either it's an old unencrypted transfer or error
-				console.log(
-					'Missing encryption key for transfer. Possibly old unencrypted transfer or incorrect client.'
+				if (!encrypted_key) {
+					// If no key, either it's an old unencrypted transfer or error
+					console.log(
+						'Missing encryption key for transfer. Possibly old unencrypted transfer or incorrect client.'
+					);
+					throw new Error(
+						'Unable to decrypt this file. Please check your access link or try again.'
+					);
+				}
+
+				// Load User's Private Key from Storage
+				const storedJWK = sessionStorage.getItem('file_access_key');
+				if (!storedJWK) {
+					throw new Error('Decryption key not found. Please Login again.');
+				}
+
+				// Rehydrate Private Key
+				const privateKey = await importKey(
+					JSON.parse(storedJWK),
+					'jwk',
+					RSA_ALGORITHM,
+					true,
+					['decrypt', 'unwrapKey']
 				);
-				throw new Error(
-					'Unable to decrypt this file. Please check your access link or try again.'
+
+				// Unwrap the Session Key (Digital Envelope)
+				const sessionKey = await unwrapSessionKey(encrypted_key, privateKey);
+
+				// Store in State for downloads
+				setDecryptionKey(sessionKey);
+				setreceivedFiles(files);
+			} else {
+				// Anonymous sharing - no decryption, just fetch file metadata
+				const hash = location.hash.slice(1); // Remove the '#' character
+				if (!hash) {
+					throw new Error('Invalid Link');
+				}
+
+				const response = await axios.get(
+					`${import.meta.env.VITE_API_BASE_URL}/api/v1/public/share/${sharingCode}`,
+					{ withCredentials: true }
 				);
+
+				const { files } = response?.data?.data || {};
+				if (!files || !Array.isArray(files) || files.length === 0) {
+					throw new Error('No files found for this sharing code');
+				}
+				setreceivedFiles(files || []);
+				const sessionKey = await importKey(
+					base64ToArrayBuffer(fromUrlSafeBase64(hash)),
+					'raw',
+					'AES-GCM',
+					false,
+					['decrypt']
+				);
+				setDecryptionKey(sessionKey);
 			}
 
-			// Load User's Private Key from Storage
-			const storedJWK = sessionStorage.getItem('file_access_key');
-			if (!storedJWK) {
-				throw new Error('Decryption key not found. Please Login again.');
-			}
-
-			// Rehydrate Private Key
-			const privateKey = await importKey(JSON.parse(storedJWK), 'jwk', RSA_ALGORITHM, true, [
-				'decrypt',
-				'unwrapKey',
-			]);
-
-			// Unwrap the Session Key (Digital Envelope)
-			const sessionKey = await unwrapSessionKey(encrypted_key, privateKey);
-
-			// Store in State for downloads
-			setDecryptionKey(sessionKey);
-			setreceivedFiles(files);
 			toast.success('Files received successfully');
 		} catch (error: unknown) {
 			if (axios.isAxiosError(error)) {
 				console.error(error.response?.data?.message);
 				toast.error(error.response?.data?.message || 'Failed to fetch files');
 			} else {
-				console.error(error);
-				toast.error('An unexpected error occurred');
+				const errorMessage =
+					error instanceof Error ? error.message : 'An unexpected error occurred';
+				console.error(errorMessage);
+				toast.error(errorMessage);
 			}
 		}
 	};
 
 	const onSubmit = async ({ sharingCode }: ReceiveInput) => {
-		await fetchFiles(sharingCode);
-		reset();
-		navigate('/share/receive');
+		await fetchFiles(sharingCode, user ? 'verified' : 'anonymous');
+		// reset();
+		// navigate('/share/receive'); // Can't reset or navigate away as hash will be lost
 	};
 
 	const handleDownload = async (index: number) => {
@@ -105,26 +159,32 @@ const FileReceive: React.FC = () => {
 			}
 
 			setDownloadingIndex(index);
+			console.log('IsAnonymousShare:', isAnonymousShare.current);
+			const presignUrl = isAnonymousShare.current
+				? `/api/v1/public/share/${shareCode.current}/presign-download/${index}`
+				: `/api/v1/share/${shareCode.current}/presign-download/${index}`;
 
 			// Request presigned download URL
-			const response = await axios.get(
-				`${import.meta.env.VITE_API_BASE_URL}/api/v1/share/${shareCode.current}/presign-download/${index}`,
-				{ withCredentials: true }
-			);
+			const response = await axios.get(`${import.meta.env.VITE_API_BASE_URL}${presignUrl}`, {
+				withCredentials: true,
+			});
 
 			const { url, content_type, filename } = response.data?.data || {};
 			if (!url) throw new Error('Download URL not received');
-
 			// Fetch the file directly from R2 using the presigned URL
-			const fileResponse = await axios.get(url, {
-				responseType: 'blob',
-			});
+			const fileResponse = await fetch(url);
+
+			if (!fileResponse.ok) {
+				throw new Error(
+					`${fileResponse.status} : R2 Download failed: ${fileResponse.statusText}`
+				);
+			}
+
+			// Extract the blob from the fetch response
+			const encryptedBlob = await fileResponse.blob();
 
 			// DECRYPT FILE LOCALLY
-			const decryptedBuffer = await decryptFileWithSessionKey(
-				fileResponse.data,
-				decryptionKey
-			);
+			const decryptedBuffer = await decryptFileWithSessionKey(encryptedBlob, decryptionKey);
 
 			// Create object URL and trigger download
 			const blob = new Blob([decryptedBuffer], {
@@ -188,16 +248,16 @@ const FileReceive: React.FC = () => {
 
 			<div className="relative z-10 min-h-screen">
 				{/* Breadcrumb */}
-									<div className="mb-4 mt-8 mx-4 px-2 max-sm:px-0">
-										<Link
-											to="/dashboard"
-											className="inline-flex items-center gap-2 text-p4/70 hover:text-p4 transition-colors text-sm rounded-md px-2 py-1"
-											aria-label="Back to dashboard"
-										>
-											<ChevronLeft size={16} className="text-p1" />
-											<span>Back to dashboard</span>
-										</Link>
-									</div>
+				<div className="mb-4 mt-8 mx-4 px-2 max-sm:px-0">
+					<Link
+						to="/dashboard"
+						className="inline-flex items-center gap-2 text-p4/70 hover:text-p4 transition-colors text-sm rounded-md px-2 py-1"
+						aria-label="Back to dashboard"
+					>
+						<ChevronLeft size={16} className="text-p1" />
+						<span>Back to dashboard</span>
+					</Link>
+				</div>
 				{/* Header */}
 				<motion.header
 					initial={{ opacity: 0, y: -20 }}
@@ -205,8 +265,6 @@ const FileReceive: React.FC = () => {
 					transition={{ duration: 0.6 }}
 					className="pt-8 pb-6 px-6 text-center max-w-4xl mx-auto"
 				>
-					
-
 					<h1 className="text-5xl font-bold mb-3 text-p4 max-md:text-4xl max-sm:text-3xl">
 						Receive Files
 					</h1>
@@ -235,7 +293,9 @@ const FileReceive: React.FC = () => {
 									<div className="bg-gradient-to-br from-purple-500/20 to-blue-500/20 p-3 rounded-xl">
 										<Package className="text-p1" size={24} />
 									</div>
-									<h2 className="text-xl font-bold text-p4">Enter Sharing Code</h2>
+									<h2 className="text-xl font-bold text-p4">
+										Enter Sharing Code
+									</h2>
 								</div>
 
 								<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
@@ -330,8 +390,12 @@ const FileReceive: React.FC = () => {
 											>
 												<Inbox className="text-p4/30 mb-4" size={80} />
 											</motion.div>
-											<p className="text-p4/60 text-base font-medium mb-2">No Files Yet</p>
-											<p className="text-p4/40 text-sm">Enter a sharing code to access files</p>
+											<p className="text-p4/60 text-base font-medium mb-2">
+												No Files Yet
+											</p>
+											<p className="text-p4/40 text-sm">
+												Enter a sharing code to access files
+											</p>
 										</motion.div>
 									) : (
 										<motion.div
@@ -344,10 +408,15 @@ const FileReceive: React.FC = () => {
 											{/* Files Stats */}
 											<div className="flex items-center justify-between mb-4 bg-s1/30 border border-s4/25 rounded-xl px-4 py-3 flex-shrink-0">
 												<div className="flex items-center gap-3">
-													<CheckCircle2 className="text-green-400" size={20} />
+													<CheckCircle2
+														className="text-green-400"
+														size={20}
+													/>
 													<span className="text-p4 font-semibold text-sm">
 														{receivedFiles.length}{' '}
-														{receivedFiles.length === 1 ? 'file' : 'files'}
+														{receivedFiles.length === 1
+															? 'file'
+															: 'files'}
 													</span>
 												</div>
 												<span className="text-p4/70 font-medium text-sm">
@@ -367,13 +436,23 @@ const FileReceive: React.FC = () => {
 													>
 														<div className="flex items-center gap-3 flex-1 min-w-0">
 															<div className="bg-gradient-to-br from-purple-500/20 to-blue-500/20 p-2.5 rounded-lg flex-shrink-0">
-																<FileIcon className="text-p1" size={20} />
+																<FileIcon
+																	className="text-p1"
+																	size={20}
+																/>
 															</div>
 															<div className="flex-1 min-w-0">
-																<p title={file.name} className="text-p4 truncate font-medium text-sm mb-0.5">
+																<p
+																	title={file.name}
+																	className="text-p4 truncate font-medium text-sm mb-0.5"
+																>
 																	{file.name}
 																</p>
-																<p className="text-p4/60 text-xs">{formatFileSize(Number(file.size))}</p>
+																<p className="text-p4/60 text-xs">
+																	{formatFileSize(
+																		Number(file.size)
+																	)}
+																</p>
 															</div>
 														</div>
 														<Button
@@ -385,9 +464,15 @@ const FileReceive: React.FC = () => {
 															title="Download file"
 														>
 															{downloadingIndex === index ? (
-																<Loader2 className="text-green-400 animate-spin" size={16} />
+																<Loader2
+																	className="text-green-400 animate-spin"
+																	size={16}
+																/>
 															) : (
-																<Download className="text-green-400" size={16} />
+																<Download
+																	className="text-green-400"
+																	size={16}
+																/>
 															)}
 														</Button>
 													</motion.div>

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -7,7 +7,9 @@ import {
 	wrapSessionKeyForRecipient,
 	base64ToArrayBuffer,
 	RSA_ALGORITHM,
+	exportKey,
 } from '@/crypto';
+import { toUrlSafeBase64 } from '@/lib/utils';
 import axios from 'axios';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -193,18 +195,23 @@ const FileUpload: React.FC = () => {
 			}
 
 			// Extract public keys for comma separated list
-			const recipientPubKeys = recipientPubKey.split(',').map((key) => key.trim()).filter((key) => key.length > 0);
-			if (recipientPubKeys.length === 0) {
+			const recipientPubKeys = recipientPubKey
+				.split(',')
+				.map((key) => key.trim())
+				.filter((key) => key.length > 0);
+			if (receiverMode === 'verified' && recipientPubKeys.length === 0) {
 				toast.error('No recipient public keys provided');
 				return;
 			}
 
-			const maxUploadSize = 100 << 20; // 100 MB
+			const maxUploadSize = 8 * 1024 * 1024 * 1024; // 8 GB
 
 			if (files.reduce((acc, file) => acc + file.size, 0) > maxUploadSize) {
-				toast.error('Total file size exceeds 100MB limit');
+				toast.error('Total file size exceeds 8 GB limit');
 				return;
 			}
+
+			let wrappedKeys: { publicKey: string; encryptedKey: string }[] = [];
 
 			setIsUploading(true);
 
@@ -216,23 +223,28 @@ const FileUpload: React.FC = () => {
 				})
 			);
 
-			// DIGITAL ENVELOPS: Wrap AES key with recipient's public key
-			const wrappedKeys = await Promise.all(
-				recipientPubKeys.map(async (pubKey) => {
-					const importedPubKey = await importKey(
-						base64ToArrayBuffer(pubKey),
-						'spki',
-						RSA_ALGORITHM,
-						true,
-						['wrapKey']
-					);
-					const wrappedKey = await wrapSessionKeyForRecipient(sessionKey, importedPubKey);
-					return {
-						publicKey: pubKey,
-						encryptedKey: wrappedKey,
-					};
-				})
-			);
+			if (receiverMode === 'verified') {
+				// DIGITAL ENVELOPS: Wrap AES key with recipient's public key
+				wrappedKeys = await Promise.all(
+					recipientPubKeys.map(async (pubKey) => {
+						const importedPubKey = await importKey(
+							base64ToArrayBuffer(pubKey),
+							'spki',
+							RSA_ALGORITHM,
+							true,
+							['wrapKey']
+						);
+						const wrappedKey = await wrapSessionKeyForRecipient(
+							sessionKey,
+							importedPubKey
+						);
+						return {
+							publicKey: pubKey,
+							encryptedKey: wrappedKey,
+						};
+					})
+				);
+			}
 
 			// 1. Request presigned URLs
 			const payload = encryptedFiles.map((file) => ({
@@ -251,17 +263,34 @@ const FileUpload: React.FC = () => {
 
 			for (let i = 0; i < encryptedFiles.length; i++) {
 				const file = encryptedFiles[i];
-
 				const { uploadURL } = results.urls[i];
-				await axios.put(uploadURL, file.encryptedBlob, {
+
+				const response = await fetch(uploadURL, {
+					method: 'PUT',
+					body: file.encryptedBlob,
 					headers: {
 						'Content-Type': 'application/octet-stream',
 					},
 				});
+
+				if (!response.ok) {
+					throw new Error(`${response.status}: R2 Upload failed: ${response.statusText}`);
+				}
 			}
 
-			const completeUploadPayload = {
+			let completeUploadPayload: {
+				token: string;
+				isAnonymous: boolean;
+				files: {
+					filename: string;
+					size: number;
+					key: string;
+					contentType: string;
+				}[];
+				wrappedKeys?: { publicKey: string; encryptedKey: string }[]; // Optional wrapped keys
+			} = {
 				token: results.token,
+				isAnonymous: receiverMode === 'anonymous',
 				files: results.urls.map(
 					(url: { filename: string; uploadURL: string; key: string }, index: number) => ({
 						filename: files[index].name,
@@ -270,8 +299,9 @@ const FileUpload: React.FC = () => {
 						contentType: files[index].type,
 					})
 				),
-				recipientKeys: wrappedKeys,
 			};
+
+			if (receiverMode === 'verified') completeUploadPayload['wrappedKeys'] = wrappedKeys;
 
 			const completeUploadRes = await axios.post(
 				`${import.meta.env.VITE_API_BASE_URL}/api/v1/files/complete`,
@@ -285,7 +315,10 @@ const FileUpload: React.FC = () => {
 			);
 
 			const code = completeUploadRes.data?.data?.share_code;
-			const fullUrl = `${window.location.origin}/share/receive?scode=${code}`;
+			let fullUrl = `${window.location.origin}/share/receive?scode=${code}`;
+
+			const exportedKey = (await exportKey(sessionKey, 'raw')) as string;
+			if (receiverMode === 'anonymous') fullUrl += `#${toUrlSafeBase64(exportedKey)}`;
 
 			setShareCode(code);
 			setShareUrl(fullUrl);
@@ -444,8 +477,6 @@ const FileUpload: React.FC = () => {
 					transition={{ duration: 0.6 }}
 					className="pt-8 pb-6 px-6 text-center max-w-4xl mx-auto w-full"
 				>
-
-
 					<h1 className="text-5xl font-bold mb-3 text-p4 max-md:text-4xl max-sm:text-3xl">
 						{uploadComplete ? '' : 'Upload Files'}
 					</h1>
@@ -481,10 +512,13 @@ const FileUpload: React.FC = () => {
 										<div className="relative border-2 border-s4/25 bg-s1/50 backdrop-blur-xl rounded-3xl shadow-2xl overflow-hidden p-6 max-md:p-5 max-sm:p-4">
 											{receiverMode && (
 												<div className="mb-3 flex justify-end">
-													<span className={`inline-flex items-center justify-center gap-1.5 text-xs px-3 py-1.5 rounded-full border text-p4 ${receiverMode === 'verified'
-															? 'border-blue-500/40 bg-blue-500/10'
-															: 'border-purple-500/40 bg-purple-500/10'
-														}`}>
+													<span
+														className={`inline-flex items-center justify-center gap-1.5 text-xs px-3 py-1.5 rounded-full border text-p4 ${
+															receiverMode === 'verified'
+																? 'border-blue-500/40 bg-blue-500/10'
+																: 'border-purple-500/40 bg-purple-500/10'
+														}`}
+													>
 														{receiverMode === 'verified' ? (
 															<>
 																<CheckCircle className="w-3.5 h-3.5 text-p1" />
@@ -564,7 +598,9 @@ const FileUpload: React.FC = () => {
 													type="text"
 													placeholder="Enter recipient's public key"
 													value={recipientPubKey}
-													onChange={(e) => setRecipientPubKey(e.target.value)}
+													onChange={(e) =>
+														setRecipientPubKey(e.target.value)
+													}
 													className="mt-4 w-full border-s4/25 rounded-xl py-6 focus:border-p1/50 focus:bg-s1/30 focus:outline-none focus:ring-2 focus:ring-s1/70 transition-all duration-300"
 												/>
 											)}
@@ -793,38 +829,40 @@ const FileUpload: React.FC = () => {
 											{/* Share Details */}
 											<div className="space-y-4">
 												{/* Share Code */}
-												<div>
-													<label className="flex items-center gap-2 text-sm font-semibold text-p4 mb-2 max-sm:text-xs">
-														<LinkIcon
-															size={16}
-															className="text-p1 max-sm:size-4"
-														/>
-														Share Code
-													</label>
-													<div className="flex items-center gap-2 w-full">
-														<div className="flex-1 flex items-center bg-s1/30 border-2 border-s4/25 rounded-xl px-4 py-3 max-sm:px-3 max-sm:py-2 min-w-0 overflow-hidden">
-															<span className="text-p4 font-mono text-lg truncate font-bold max-sm:text-base w-full">
-																{shareCode}
-															</span>
-														</div>
-														<Button
-															variant="ghost"
-															size="icon"
-															className="bg-s1/30 hover:bg-s1/40 border-2 border-s4/25 rounded-xl h-12 w-12 cursor-pointer flex-shrink-0 max-sm:h-10 max-sm:w-10"
-															onClick={() => {
-																navigator.clipboard.writeText(
-																	shareCode
-																);
-																toast.success('Code copied!');
-															}}
-														>
-															<Copy
+												{receiverMode === 'verified' && (
+													<div>
+														<label className="flex items-center gap-2 text-sm font-semibold text-p4 mb-2 max-sm:text-xs">
+															<LinkIcon
+																size={16}
 																className="text-p1 max-sm:size-4"
-																size={18}
 															/>
-														</Button>
+															Share Code
+														</label>
+														<div className="flex items-center gap-2 w-full">
+															<div className="flex-1 flex items-center bg-s1/30 border-2 border-s4/25 rounded-xl px-4 py-3 max-sm:px-3 max-sm:py-2 min-w-0 overflow-hidden">
+																<span className="text-p4 font-mono text-lg truncate font-bold max-sm:text-base w-full">
+																	{shareCode}
+																</span>
+															</div>
+															<Button
+																variant="ghost"
+																size="icon"
+																className="bg-s1/30 hover:bg-s1/40 border-2 border-s4/25 rounded-xl h-12 w-12 cursor-pointer flex-shrink-0 max-sm:h-10 max-sm:w-10"
+																onClick={() => {
+																	navigator.clipboard.writeText(
+																		shareCode
+																	);
+																	toast.success('Code copied!');
+																}}
+															>
+																<Copy
+																	className="text-p1 max-sm:size-4"
+																	size={18}
+																/>
+															</Button>
+														</div>
 													</div>
-												</div>
+												)}
 
 												{/* Share URL */}
 												<div>
@@ -945,14 +983,12 @@ const FileUpload: React.FC = () => {
 						initial={{ opacity: 0 }}
 						animate={{ opacity: 1 }}
 						exit={{ opacity: 0 }}
-
 						className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/90 backdrop-blur-sm px-4"
 					>
 						<motion.div
 							initial={{ scale: 0.85, opacity: 0 }}
 							animate={{ scale: 1, opacity: 1 }}
 							exit={{ scale: 0.85, opacity: 0 }}
-
 							transition={{ type: 'spring', stiffness: 260, damping: 20 }}
 							className="w-full max-w-md bg-s1 border-2 border-s4/25 rounded-2xl p-6 shadow-2xl"
 						>
@@ -964,10 +1000,11 @@ const FileUpload: React.FC = () => {
 								{/* Anonymous */}
 								<div
 									onClick={() => setReceiverMode('anonymous')}
-									className={`cursor-pointer flex flex-col items-center text-center gap-2 border rounded-xl p-4 transition-all hover:scale-105 ${receiverMode === 'anonymous'
-										? 'border-p1 bg-s1/40'
-										: 'border-s4/25 hover:bg-s1/30'
-										}`}
+									className={`cursor-pointer flex flex-col items-center text-center gap-2 border rounded-xl p-4 transition-all hover:scale-105 ${
+										receiverMode === 'anonymous'
+											? 'border-p1 bg-s1/40'
+											: 'border-s4/25 hover:bg-s1/30'
+									}`}
 								>
 									<div className="p-3 rounded-xl bg-purple-500/20">
 										<UserX className="text-p1" size={22} />
@@ -981,10 +1018,11 @@ const FileUpload: React.FC = () => {
 								{/* Verified */}
 								<div
 									onClick={() => setReceiverMode('verified')}
-									className={`cursor-pointer flex flex-col items-center text-center gap-2 border rounded-xl p-4 transition-all hover:scale-105 ${receiverMode === 'verified'
-										? 'border-p1 bg-s1/40'
-										: 'border-s4/25 hover:bg-s1/30'
-										}`}
+									className={`cursor-pointer flex flex-col items-center text-center gap-2 border rounded-xl p-4 transition-all hover:scale-105 ${
+										receiverMode === 'verified'
+											? 'border-p1 bg-s1/40'
+											: 'border-s4/25 hover:bg-s1/30'
+									}`}
 								>
 									<div className="p-3 rounded-xl bg-blue-500/20">
 										<CheckCircle2 className="text-p1" size={22} />

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -25,7 +25,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 				withCredentials: true,
 				signal: controller.signal,
 			})
-			.then((res) => setUser(res.data))
+			.then((res) => setUser(res.data.data))
 			.catch((err) => {
 				if (err.name === 'CanceledError' || err.name === 'AbortError') return;
 				setUser(null);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,3 +14,8 @@ export const formatFileSize = (bytes: number) => {
 	const gb = mb / 1024;
 	return gb.toFixed(2) + ' GB';
 };
+
+export const toUrlSafeBase64 = (b64: string) =>
+	b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+export const fromUrlSafeBase64 = (b64: string) => b64.replace(/-/g, '+').replace(/_/g, '/');


### PR DESCRIPTION
### Updates
- Increase file sharing size limit to 8GB for large file size testing
- set actual user info to auth context instead of response data
- feat(utils): add URL-safe Base64 encoding and decoding functions
- feat(FileUpload): increase max upload size to 8 GB and adjust handling for anonymous sharing
- feat(FileReceive): implement anonymous sharing receiving flow